### PR TITLE
fix: same city's separate paths now highlight together on hover

### DIFF
--- a/css/svg-turkiye-haritasi.css
+++ b/css/svg-turkiye-haritasi.css
@@ -23,11 +23,11 @@
   -moz-border-radius: 4px;
   border-radius: 4px;
 }
-#svg-turkiye-haritasi path {
+#svg-turkiye-haritasi g {
   cursor: pointer;
   fill: #222;
 }
-#svg-turkiye-haritasi path:hover {
+#svg-turkiye-haritasi g:hover {
   fill: #1094F6;
 }
 #guney-kibris {


### PR DESCRIPTION
bkz: Çanakkale, Balıkesir, İstanbul (Asya)
İstanbul asya is still separate from İstanbul (Avrupa) but the islands were being separately highlighted in İstanbul(Asya). Now it's fixed.

![before](https://user-images.githubusercontent.com/29009961/228121775-dec1cee0-b064-4953-a059-9655f7dda73f.png)
![after](https://user-images.githubusercontent.com/29009961/228121778-eff1af40-ca5b-468f-b913-22a4b72a8d4a.png)
